### PR TITLE
Exeptions

### DIFF
--- a/doc/src/manual/Main.janet
+++ b/doc/src/manual/Main.janet
@@ -103,43 +103,38 @@ native "C++" {
         std::cout.flush();
     }
 
-    native "C++" String sortJavaStringInUTF(String s) {
-        std::vector<char> sorted;
+    native "C++" String echoInUTF(String s) {
+        std::vector<char> result;
         {
             const char* content = `#&s`;
             int len = strlen(content);
-            sorted.resize(len + 1);
-            strcpy(&*sorted.begin(), content);
-            std::sort(sorted.begin(), sorted.end() - 1);  // Don't sort the terminal '\0'
-            const char* sorted_content = &*sorted.begin();
-            `return #$(sorted_content);`
+            result.resize(2 * len + 1);  // Leave space for terminal '\0'
+            strncpy(&result[0], content, len);
+            strncpy(&result[len], content, len);
+            `return #$(&result[0]);`
         }
     }
 
-    native "C++" String echoInUTF(String s) {
-        const char* content = `#&s`;
-        int len = strlen(content);
-        std::vector<char> result(2 * len + 1);  // Leave space for terminal '\0'
-        strncpy(&result[0], content, len);
-        strncpy(&result[len], content, len);
-        `return #$(&result[0]);`
-    }
-
     native "C++" String echoInUnicode(String s) {
-        const jchar* content = `&s`;
-        int len = `s.length()`;
-        std::vector<jchar> result(2 * len);
-        std::copy(content, content + len, result.begin());
-        std::copy(content, content + len, result.begin() + len);
-        `return #$$(len > 0 ? &result[0] : 0, 2 * len);`
+        std::vector<jchar> result;
+        {
+            const jchar* content = `&s`;
+            int len = `s.length()`;
+            result.resize(2 * len);
+            std::copy(content, content + len, result.begin());
+            std::copy(content, content + len, result.begin() + len);
+            `return #$$(len > 0 ? &result[0] : 0, 2 * len);`
+        }
     }
 
     native "C++" String echoInJava(String s) {
-        int len = `s.length()`;
         std::vector<jchar> result;
-        for (int i = 0; i < len; ++i) result.push_back(`s.charAt(#(i))`);
-        for (int i = 0; i < len; ++i) result.push_back(`s.charAt(#(i))`);
-        `return #$$(len > 0 ? &result[0] : 0, 2 * len);`
+        {
+            int len = `s.length()`;
+            for (int i = 0; i < len; ++i) result.push_back(`s.charAt(#(i))`);
+            for (int i = 0; i < len; ++i) result.push_back(`s.charAt(#(i))`);
+            `return #$$(len > 0 ? &result[0] : 0, 2 * len);`
+        }
     }
 
     native "C++" String[] helloFromJanet() {

--- a/native/c/include/janet.h
+++ b/native/c/include/janet.h
@@ -70,38 +70,73 @@ static _janet_multiref* _janet_inc_multiref(JNIEnv* _janet_jnienv,
 #define _JANET_DEC_MULTIREF(pref) \
     _janet_dec_multiref(_janet_jnienv, pref)
 
+static void _janet_destroy_multiref(JNIEnv* _janet_jnienv, _janet_multiref* pref)
+{
+    if (!pref) return;
+    _JANET_ASSERT(pref->ref);
+    /* first, array contents (if any) */
+    if (pref->arr) {
+        _JANET_ASSERT(pref->arr->ref && pref->arr->refcount > 0);
+        if (!--pref->arr->refcount) {
+            /* no other multiref pointing to this array */
+            _jh2_janet_rmArray(_janet_jnienv, pref->arr);
+        } else {
+            /* there are others; set ref to 0 in order to
+                   avoid DELETE_LOCAL_REF later on this array */
+                if (pref->ref == pref->arr->ref) pref->ref = 0;
+            }
+        pref->arr = 0;
+    }
+    /* next, string contents (if any) */
+    if (pref->struni) {
+        JNI_RELEASE_STRING_CHARS((jstring)pref->ref, pref->struni);
+        pref->struni = 0;
+    }
+    if (pref->strutf) {
+      JNI_RELEASE_STRING_UTF_CHARS((jstring)pref->ref, pref->strutf);
+      pref->strutf = 0;
+    }
+
+    pref->arrlength = -1;
+}
+
 static void _janet_dec_multiref(JNIEnv* _janet_jnienv, _janet_multiref* pref)
 {
     if (!pref) return;
     _JANET_ASSERT(pref->ref && pref->refcount > 0);
     if (!--pref->refcount) { /* refcount reached 0 -> release resources */
-        /* first, array contents (if any) */
-        if (pref->arr) {
-            _JANET_ASSERT(pref->arr->ref && pref->arr->refcount > 0);
-            if (!--pref->arr->refcount) {
-                /* no other multiref pointing to this array */
-                _jh2_janet_rmArray(_janet_jnienv, pref->arr);
-            } else {
-                /* there are others; set ref to 0 in order to
-                   avoid DELETE_LOCAL_REF later on this array */
-                if (pref->ref == pref->arr->ref) pref->ref = 0;
-            }
-            pref->arr = 0;
-        }
-	/* next, string contents (if any) */
-	if (pref->struni) {
-	    JNI_RELEASE_STRING_CHARS((jstring)pref->ref, pref->struni);
-	    pref->struni = 0;
-	}
-	if (pref->strutf) {
-	  JNI_RELEASE_STRING_UTF_CHARS((jstring)pref->ref, pref->strutf);
-	  pref->strutf = 0;
-	}
-
-        pref->arrlength = -1;
+        _janet_destroy_multiref(_janet_jnienv, pref);
     }
 }
 
+#ifdef __cplusplus
+// Top-level guard to release any resources acquired in the function that
+// have not yet been cleared. It allows us to omit _JANET_DESTRUCT at the
+// top-level scope.
+class _JanetMultirefDeleter {
+    public:
+        _JanetMultirefDeleter(JNIEnv* env, _janet_multiref* refs, size_t size)
+            : env_(env), refs_(refs), size_(size) {}
+
+        ~_JanetMultirefDeleter() {
+            for (int i = 0; i < size_; ++i) {
+                if (refs_[i].ref && refs_[i].refcount > 0) {
+                    _janet_destroy_multiref(env_, &refs_[i]);
+                }
+            }
+        }
+
+    private:
+        JNIEnv* env_;
+        _janet_multiref* refs_;
+        size_t size_;
+};
+
+#define _JANET_DECLARE_MULTIREF_DELETER \
+    _JanetMultirefDeleter _janet_multiref_deleter( \
+        _janet_jnienv, _janet_multirefs, _janet_multirefs_size)
+
+#endif
 
 static void _janet_array_install(JNIEnv* _janet_jnienv, 
                                  _janet_arrHashTable* _janet_arrhtable,
@@ -389,11 +424,9 @@ static void* _janet_array_get_jptr(JNIEnv* _janet_jnienv,
     _janet_array_install(_janet_jnienv, _janet_arrhtable, ref);
     _JANET_ASSERT(ref->arr);
     if (ref->arr->jptr) return ref->arr->jptr;
-#ifdef JANET_JNIEXT_1_2
     if (fastarrays) {
       return _jjp_critical_janet(_janet_jnienv, ref->arr, filename, lineno);
     }
-#endif
     return (*jptrfun)(_janet_jnienv, ref->arr, filename, lineno);
 }
 
@@ -527,8 +560,8 @@ struct _janet_exstruct {
 #define _JANET_RETURN_GLOBAL_V()                   \
    return
 
-#define _JANET_RETURN_GLOBAL_0()                   \
-   return _janet_ret
+#define _JANET_RETURN_GLOBAL_0(ret)                   \
+   return ret
 
 /* eating exceptions */
 

--- a/src/pl/edu/agh/icsr/janet/yytree/YYReturnStatement.java
+++ b/src/pl/edu/agh/icsr/janet/yytree/YYReturnStatement.java
@@ -58,8 +58,12 @@ public class YYReturnStatement extends YYStatement { // JLS 14.16
             }
         }
         // if we are here, assignment check was successful
-        retexpr.setImplicitCastType(mthtype);
-        addExceptions(retexpr.getExceptionsThrown());
+        if (retexpr != null) {
+            retexpr.setImplicitCastType(mthtype);
+            addExceptions(retexpr.getExceptionsThrown());
+        } else {
+            addExceptions(new HashMap());
+        }
     }
 
     public YYExpression getReturnedExpression() { return retexpr; }


### PR DESCRIPTION
Tightening rules for local exception scoping, to avoid the extent of longjmp and make sure it's safe to declare non-trivial C++ objects in a wrapper block that doesn't embed any Java directly.
